### PR TITLE
build(workspace): add shallow_since for rules_cc and platforms

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -33,6 +33,7 @@ git_repository(
     name = "rules_cc",
     commit = "a636005ba28c0344da5110bd8532184c74b6ffdf",
     remote = "https://github.com/bazelbuild/rules_cc.git",
+    shallow_since = "1583316607 -0800",
 )
 
 http_archive(

--- a/bazel_embedded_deps.bzl
+++ b/bazel_embedded_deps.bzl
@@ -12,6 +12,7 @@ def bazel_embedded_deps():
         name = "platforms",
         remote = "https://github.com/curtin-space/platforms.git",
         commit = "a9fb73e46ab4a7558d53d65ed8e608724f07d4cc",
+        shallow_since = "1585009972 +0800"
     )
 
     if not native.existing_rule("rules_cc"):

--- a/bazel_embedded_deps.bzl
+++ b/bazel_embedded_deps.bzl
@@ -20,6 +20,7 @@ def bazel_embedded_deps():
             name = "rules_cc",
             commit = "a636005ba28c0344da5110bd8532184c74b6ffdf",
             remote = "https://github.com/bazelbuild/rules_cc.git",
+            shallow_since = "1583316607 -0800",
         )
     if not native.existing_rule("bazel_skylib"):
         http_archive(


### PR DESCRIPTION
Rule 'rules_cc' indicated that a canonical reproducible form can be obtained by modifying arguments shallow_since.
Rule 'platforms' indicated that a canonical reproducible form can be obtained by modifying arguments shallow_since.