### PR TITLE
toolchains: Fixing gcc_arm exec_compatible_with

### DIFF
--- a/toolchains/gcc_arm_none_eabi/gcc_arm_none_toolchain.bzl
+++ b/toolchains/gcc_arm_none_eabi/gcc_arm_none_toolchain.bzl
@@ -272,9 +272,7 @@ def gcc_arm_none_toolchain(name, compiler_components, architecture, float_abi, e
     native.toolchain(
         name = "-".join(["cc-toolchain", architecture, fpu]),
         exec_compatible_with = [
-            "@platforms//cpu:" + architecture,
-            "//constraints/fpu:" + fpu,
-            "@platforms//os:none",
+            "@platforms//cpu:x86_64",
         ],
         target_compatible_with = [
             "@platforms//cpu:" + architecture,


### PR DESCRIPTION
This fixes a bug where the cortex_m0 platform would be selected for
building tools tagged to be built for the exec platform. This obviously
fails as most tools need a full development environment to build and
run.